### PR TITLE
Enhanced exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# 1.1.0 - 2014-11-25
+
+- Enhanced exceptions
+
+# 1.0.0 - 2014-11-01
+
+Initial release

--- a/index.js
+++ b/index.js
@@ -7,13 +7,9 @@
 
 var color = require('color');
 var reduceFunctionCall = require('reduce-function-call');
+var helpers = require('postcss-message-helpers');
 
-function gnuMessage(message, source) {
-  var fileName = source.file || '<css input>';
-  return fileName + ':' + source.start.line + ':' + source.start.column + ' ' + message;
-}
-
-function parseGray(value, source) {
+function parseGray(value) {
   return reduceFunctionCall(value, 'gray', function(argString) {
     var args = argString.split(',');
 
@@ -39,14 +35,16 @@ function parseGray(value, source) {
 
     } catch (e) {
       e.message = e.message.replace(/rgba?\(.*\)/, 'gray(' + args + ')');
-      throw new Error(gnuMessage(e.message, source));
+      throw e;
     }
   });
 }
 
 function transformDecl(decl) {
   if (decl.value && decl.value.indexOf('gray(') !== -1) {
-    decl.value = parseGray(decl.value, decl.source);
+    decl.value = helpers.try(function transformGrayValue() {
+      return parseGray(decl.value);
+    }, decl.source);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/shinnn"
   },
   "scripts": {
-    "pretest": "eslint *.js & jscs *.js",
+    "pretest": "eslint *.js && jscs *.js",
     "test": "node test.js | tap-spec",
     "coverage": "istanbul cover test.js",
     "coveralls": "${npm_package_scripts_coverage} && istanbul-coveralls"
@@ -36,6 +36,7 @@
   ],
   "dependencies": {
     "color": "^0.7.3",
+    "postcss-message-helpers": "^1.1.1",
     "reduce-function-call": "^1.0.1"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -41,7 +41,7 @@ test('filterDeclarations()', function(t) {
     function() {
       useGray().process('a {color: gray(,foo)}');
     },
-    /<css input>:1:4 Unable to parse color from string "gray\(,foo\)"/,
+    /<css input>:1:4: Unable to parse color from string "gray\(,foo\)"/,
     'should throw an error when gray() takes invalid argument.'
   );
 
@@ -49,15 +49,15 @@ test('filterDeclarations()', function(t) {
     function() {
       useGray().process('a {color: gray(red)}', {from: 'fixture.css'});
     },
-    /fixture\.css:1:4 Unable to parse color from string "gray\(red\)"/,
+    /fixture\.css:1:4: Unable to parse color from string "gray\(red\)"/,
     'should throw a detailed error when a source file is specified.'
   );
 
   t.throws(
     function() {
-      console.log(useGray().process('a {color: gray(,)}', {map: true}).css);
+      useGray().process('a {color: gray(,)}', {map: true});
     },
-    /<css input>:1:4 Unable to parse color from string "gray\(,\)"/,
+    /<css input>:1:4: Unable to parse color from string "gray\(,\)"/,
     'should throw a detailed error when source map is enabled but file isn\'t specified.'
   );
 });


### PR DESCRIPTION
This commit also contains:
- eslint + jscs break the process as they should if there is an error
- test should fail if no error is thrown on each t.throws tests
- throwing the same error keep the original stack trace

The helper I'm using only enhance exceptions that can be thrown & do not throw a new exception.

Note: I'm making a PR because I don't have npm rights for now :)
