### PR TITLE
Upgrade to PostCSS 5.x, fix specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ git:
 language: node_js
 node_js:
   - '0.10'
-  - '0.11'
+  - '0.12'
 notifications:
   email: false
 after_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ version: '{build}'
 environment:
   matrix:
     - nodejs_version: '0.10'
-    - nodejs_version: '0.11'
+    - nodejs_version: '0.12'
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "url": "https://github.com/shinnn"
   },
   "scripts": {
-    "pretest": "eslint *.js && jscs *.js",
+    "pretest": "npm run eslint && npm run jscs",
+    "eslint": "eslint index.js test.js",
+    "jscs": "jscs index.js test.js",
     "test": "node test.js | tap-spec",
     "coverage": "istanbul cover test.js",
     "coveralls": "${npm_package_scripts_coverage} && istanbul-coveralls"
@@ -39,6 +41,7 @@
   ],
   "dependencies": {
     "color": "^0.7.3",
+    "postcss": "^5.0.4",
     "postcss-message-helpers": "^2.0.0",
     "reduce-function-call": "^1.0.1"
   },
@@ -47,7 +50,6 @@
     "istanbul": "^0.3.5",
     "istanbul-coveralls": "^1.0.1",
     "jscs": "^1.8.1",
-    "postcss": "^4.0.2",
     "tap-spec": "^2.1.0",
     "tape": "^3.0.3"
   }

--- a/test.js
+++ b/test.js
@@ -9,7 +9,7 @@ function useGray() {
 }
 
 test('filterDeclarations()', function(t) {
-  t.plan(7);
+  t.plan(8);
 
   t.equal(
     useGray().process('a {color: gray(200); background: gray(00000034%)}').css,
@@ -31,7 +31,7 @@ test('filterDeclarations()', function(t) {
 
   t.throws(
     function() {
-      useGray().process('a {color: gray()}');
+      return useGray().process('a {color: gray()}').css;
     },
     /Unable to parse color from string "gray\(\)"/,
     'should throw an error when gray() doesn\'t take any arguments.'
@@ -39,15 +39,23 @@ test('filterDeclarations()', function(t) {
 
   t.throws(
     function() {
-      useGray().process('a {color: gray(,foo)}');
+      return useGray().process('a {color: gray(,foo)}').css;
     },
     /<css input>:1:4: Unable to parse color from string "gray\(,foo\)"/,
-    'should throw an error when gray() takes invalid argument.'
+    'should throw an error when gray() args start with a comma.'
   );
 
   t.throws(
     function() {
-      useGray().process('a {color: gray(red)}', {from: 'fixture.css'});
+      return useGray().process('a {color: gray(foo,)}').css;
+    },
+    /<css input>:1:4: Unable to parse color from string "gray\(foo,\)"/,
+    'should throw an error when gray() args end with a comma.'
+  );
+
+  t.throws(
+    function() {
+      return useGray().process('a {color: gray(red)}', {from: 'fixture.css'}).css;
     },
     /fixture\.css:1:4: Unable to parse color from string "gray\(red\)"/,
     'should throw a detailed error when a source file is specified.'
@@ -55,7 +63,7 @@ test('filterDeclarations()', function(t) {
 
   t.throws(
     function() {
-      useGray().process('a {color: gray(,)}', {map: true});
+      return useGray().process('a {color: gray(,)}', {map: true}).css;
     },
     /<css input>:1:4: Unable to parse color from string "gray\(,\)"/,
     'should throw a detailed error when source map is enabled but file isn\'t specified.'


### PR DESCRIPTION
Fixes #4 

Also, half of the specs were failing, so I made a number of fixes, fixed some Windows issues, constructed the plugin according to PostCSS plugin guidelines, threw errors according to the same guidelines, simplified the code and leveraged the `postcss.list.comma` method.