### PR TITLE
Add CSS Standard Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # postcss-color-gray
 
+[![CSS Standard Status](https://jonathantneal.github.io/css-db/badge/css-color-grays.svg)](https://jonathantneal.github.io/css-db/#css-color-grays)
 [![Build Status](https://travis-ci.org/postcss/postcss-color-gray.svg?branch=master)](https://travis-ci.org/postcss/postcss-color-gray)
 [![Build status](https://ci.appveyor.com/api/projects/status/190t5i4f23r49345?svg=true)](https://ci.appveyor.com/project/ShinnosukeWatanabe/postcss-color-gray)
 [![Coverage Status](https://img.shields.io/coveralls/postcss/postcss-color-gray.svg)](https://coveralls.io/r/postcss/postcss-color-gray)


### PR DESCRIPTION
Hey there. I’m just trying to get the word out that cssdb has badges to help users know the status of your CSS polyfill.

[cssdb](https://jonathantneal.github.io/css-db/) is a list I’m compiling of CSS features and their positions in the process of becoming implemented web standards.