### PR TITLE
Update packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,20 +25,20 @@
     "node": ">=6.0.0"
   },
   "dependencies": {
-    "@csstools/convert-colors": "^1.4.0",
-    "postcss": "^7.0.5",
-    "postcss-values-parser": "^2.0.0"
+    "@csstools/convert-colors": "^2.0.0",
+    "postcss": "^7.0.17",
+    "postcss-values-parser": "^3.0.4"
   },
   "devDependencies": {
-    "@babel/core": "^7.0.0",
-    "@babel/preset-env": "^7.0.0",
+    "@babel/core": "^7.4.5",
+    "@babel/preset-env": "^7.4.5",
     "babel-eslint": "^10.0.1",
-    "eslint": "^5.6.1",
+    "eslint": "^5.16.0",
     "eslint-config-dev": "^2.0.0",
-    "postcss-tape": "^2.2.0",
+    "postcss-tape": "^5.0.0",
     "pre-commit": "^1.2.2",
-    "rollup": "^0.66.5",
-    "rollup-plugin-babel": "^4.0.1"
+    "rollup": "^1.15.1",
+    "rollup-plugin-babel": "^4.3.2"
   },
   "eslintConfig": {
     "extends": "dev",


### PR DESCRIPTION
I've updated the dependencies and ran the tests.
This should fix the flatten dependency warning.