### PR TITLE
remove : postcss-values-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@csstools/convert-colors": "^2.0.0",
-    "postcss-values-parser": "^5.0.0"
+    "postcss-value-parser": "^4.2.0"
   },
   "peerDependencies": {
     "postcss": "^8.0.0"


### PR DESCRIPTION
see : https://github.com/csstools/postcss-preset-env/issues/228

PostCSS Values Parser is causing a lot of issues lately and I needed this plugin without it.
Don't need it published as I just needed it once.

Just thought it might save someone time if there is a need for this update.